### PR TITLE
Add appstart using navigationservice

### DIFF
--- a/MvxForms/MvxForms.Core/MvxApp.cs
+++ b/MvxForms/MvxForms.Core/MvxApp.cs
@@ -32,7 +32,7 @@ namespace MvxForms.Core
 
             Resources.AppResources.Culture = Mvx.Resolve<Services.ILocalizeService>().GetCurrentCultureInfo();
 
-            RegisterAppStart<ViewModels.MainViewModel>();
+            RegisterNavigationServiceAppStart<ViewModels.MainViewModel>();
         }
     }
 }

--- a/MvxFormsTemplate/MvxForms.Core/MvxApp.cs
+++ b/MvxFormsTemplate/MvxForms.Core/MvxApp.cs
@@ -32,7 +32,7 @@ namespace $safeprojectname$
 
             Resources.AppResources.Culture = Mvx.Resolve<Services.ILocalizeService>().GetCurrentCultureInfo();
 
-            RegisterAppStart<ViewModels.MainViewModel>();
+            RegisterNavigationServiceAppStart<ViewModels.MainViewModel>();
         }
     }
 }


### PR DESCRIPTION
Since 5.0, using RegisterAppStart causes the lifecycle events on the first viewmodel not to fire. RegisterNavigationServiceAppStart was introduced to fix this, as seen [here](https://github.com/MvvmCross/MvvmCross/pull/2042).